### PR TITLE
Add cleanup step to release workflow on failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,19 +183,19 @@ jobs:
           registry-url: 'https://registry.npmjs.org' # Setup .npmrc file to unpublish from npm
 
       - name: Unpublish arm64-linux-gnu-${{ matrix.node }}
-        run: npm unpublish arm64-linux-gnu-${{ matrix.node }}@${{ github.event.inputs.releasing }}
+        run: npm unpublish solarwinds-apm-bindings-arm64-linux-gnu-${{ matrix.node }}@${{ github.event.inputs.releasing }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Unpublish arm64-linux-musl-${{ matrix.node }}
-        run: npm unpublish arm64-linux-musl-${{ matrix.node }}@${{ github.event.inputs.releasing }}
+        run: npm unpublish solarwinds-apm-bindings-arm64-linux-musl-${{ matrix.node }}@${{ github.event.inputs.releasing }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Unpublish x64-linux-gnu-${{ matrix.node }}
-        run: npm unpublish x64-linux-gnu-${{ matrix.node }}@${{ github.event.inputs.releasing }}
+        run: npm unpublish solarwinds-apm-bindings-x64-linux-gnu-${{ matrix.node }}@${{ github.event.inputs.releasing }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Unpublish x64-linux-gnu-${{ matrix.node }}
-        run: npm unpublish x64-linux-musl-${{ matrix.node }}@${{ github.event.inputs.releasing }}
+        run: npm unpublish solarwinds-apm-bindings-x64-linux-musl-${{ matrix.node }}@${{ github.event.inputs.releasing }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,39 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
         if: ${{ !contains(github.event.inputs.releasing, '-') }}
 
+  unpublish-prebuilt:
+    name: Unpublish prebuilt platform-specific packages
+    runs-on: ubuntu-latest
+    needs: [build-publish-prebuilt, x64-group-install]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    strategy:
+      matrix:
+        node: ['14', '16', '18']
+
+    steps:
+      - name: Setup Node ${{ matrix.node }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          registry-url: 'https://registry.npmjs.org' # Setup .npmrc file to unpublish from npm
+
+      - name: Unpublish arm64-linux-gnu-${{ matrix.node }}
+        run: npm unpublish arm64-linux-gnu-${{ matrix.node }}@${{ github.event.inputs.releasing }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Unpublish arm64-linux-musl-${{ matrix.node }}
+        run: npm unpublish arm64-linux-musl-${{ matrix.node }}@${{ github.event.inputs.releasing }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Unpublish x64-linux-gnu-${{ matrix.node }}
+        run: npm unpublish x64-linux-gnu-${{ matrix.node }}@${{ github.event.inputs.releasing }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Unpublish x64-linux-gnu-${{ matrix.node }}
+        run: npm unpublish x64-linux-musl-${{ matrix.node }}@${{ github.event.inputs.releasing }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       # Why Change Owner of Container Working Directory?
 
       # the working directory is created by the runner and mounted to the container.


### PR DESCRIPTION
This adds a step to the release workflow that only runs on failure to unpublish the prebuilt packages since the parent package has not been published