### PR TITLE
Node 20 support

### DIFF
--- a/.github/config/docker-node.json
+++ b/.github/config/docker-node.json
@@ -14,6 +14,9 @@
     },
     {
       "tag": "18-amazonlinux2022"
+    },
+    {
+      "tag": "20-amazonlinux2022"
     }
   ]
 }

--- a/.github/config/test-group.json
+++ b/.github/config/test-group.json
@@ -65,6 +65,21 @@
     },
     {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:18-amazonlinux2022"
+    },
+    {
+      "image": "node:20-alpine3.16"
+    },
+    {
+      "image": "node:20-alpine"
+    },
+    {
+      "image": "node:20-buster"
+    },
+    {
+      "image": "node:20-bullseye"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:20-amazonlinux2022"
     }
   ]
 }

--- a/.github/docker-node/14-amazonlinux2.Dockerfile
+++ b/.github/docker-node/14-amazonlinux2.Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ENV NODE_VERSION 14.21.2
+ENV NODE_VERSION 14.21.3
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/14-ubuntu18.04.Dockerfile
+++ b/.github/docker-node/14-ubuntu18.04.Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ENV NODE_VERSION 14.21.2
+ENV NODE_VERSION 14.21.3
 
 # install software required for this OS
 RUN apt-get update && apt-get install -y curl

--- a/.github/docker-node/16-amazonlinux2.Dockerfile
+++ b/.github/docker-node/16-amazonlinux2.Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ENV NODE_VERSION 16.19.0
+ENV NODE_VERSION 16.20.0
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/16-ubuntu18.04.Dockerfile
+++ b/.github/docker-node/16-ubuntu18.04.Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ENV NODE_VERSION 16.19.0
+ENV NODE_VERSION 16.20.0
 
 # install software required for this OS
 RUN apt-get update && apt-get install -y curl

--- a/.github/docker-node/20-amazonlinux2022.Dockerfile
+++ b/.github/docker-node/20-amazonlinux2022.Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2022
 
-ENV NODE_VERSION 18.16.0
+ENV NODE_VERSION 20.0.0
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,9 +43,9 @@ jobs:
           path: |
             ~/.zig-build
             ~/.cache/zig
-          key: zig-build-${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
+          key: zig-build-${{ github.event.inputs.node || '18' }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            zig-build-${{ matrix.node }}-
+            zig-build-${{ github.event.inputs.node || '18' }}-
 
       - name: Show Environment Info
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     needs: is-publishable
     strategy:
       matrix:
-        node: ['14', '16', '18']
+        node: ['14', '16', '18', '20']
     
     steps:
       - name: Checkout ${{ github.ref }}
@@ -237,7 +237,7 @@ jobs:
     if: always() && contains(needs.*.result, 'failure')
     strategy:
       matrix:
-        node: ['14', '16', '18']
+        node: ['14', '16', '18', '20']
       fail-fast: false
 
     steps:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -160,6 +160,12 @@ jobs:
         with:
           name: npm-18
           path: npm/
+      - name: Download Node 20 packages
+        if: ${{ contains(matrix.image, '20') }}
+        uses: actions/download-artifact@v3
+        with:
+          name: npm-20
+          path: npm/
 
       - name: NPM Install dependencies
         run: npm install

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', '16', '18']
+        node: ['14', '16', '18', '20']
     
     steps:
       - name: Checkout ${{ github.ref }}

--- a/build.js
+++ b/build.js
@@ -28,15 +28,15 @@ const bindings = {
 
 /** @type{import('zig-build').Target} */
 const metrics = {
-  std: 'c++14',
+  std: 'c++17',
   sources: [
     'src/metrics/metrics.cc',
     'src/metrics/gc.cc',
     'src/metrics/eventloop.cc',
     'src/metrics/process.cc'
   ],
-  libraries: ['oboe'],
   include: [__dirname, nan],
+  libraries: ['oboe'],
   rpath: '$ORIGIN',
   cflags: ['-Wall', '-Wextra']
 }

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -29,11 +29,12 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | b
 # these are the stable versions as of January 2022
 # can't use lts alias due to all sorts of Dockerfile limitations.
 RUN source $NVM_DIR/nvm.sh \
-    && nvm install v18.13.0 \
-    && nvm install v16.19.0 \
-    && nvm install v14.21.2 \
+    && nvm install v20.0.0 \
+    && nvm install v18.16.0 \
+    && nvm install v16.20.0 \
+    && nvm install v14.21.3 \
     && nvm install stable
 
 # add node and npm to path so the commands are available
-ENV NODE_PATH $NVM_DIR/v18.13.0/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v18.13.0/bin:$PATH
+ENV NODE_PATH $NVM_DIR/v20.0.0/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v20.0.0/bin:$PATH

--- a/dev/docker-compose.build.yml
+++ b/dev/docker-compose.build.yml
@@ -21,3 +21,10 @@ services:
     working_dir: /work
     entrypoint: /bin/sh -lc
     command: [npm install && npm run build]
+  node-20:
+    image: node:20-alpine
+    volumes:
+      - ..:/work
+    working_dir: /work
+    entrypoint: /bin/sh -lc
+    command: [npm install && npm run build]

--- a/index.js
+++ b/index.js
@@ -26,19 +26,30 @@ try {
   try {
     bindings = require(`solarwinds-apm-bindings-${p}/bindings.node`)
     metrics = require(`solarwinds-apm-bindings-${p}/metrics.node`)
-  } catch {
-    console.warn(`platform ${p} not supported`)
+  } catch (err) {
+    console.warn(`platform ${p} not supported`, err)
   }
 } finally {
-  if (bindings && metrics) {
+  module.exports.version = require('./package.json').version
+
+  if (bindings) {
     module.exports = bindings
 
-    module.exports.version = require('./package.json').version
     module.exports.init = function (sk) {
       return module.exports.oboeInit({ serviceKey: sk || process.env.SW_APM_SERVICE_KEY })
     }
 
-    module.exports.metrics = metrics
+    if (metrics) {
+      module.exports.metrics = metrics
+    } else {
+      console.warn("metrics disabled")
+
+      module.exports.metrics = {
+        start () { return true },
+        stop () { return true },
+        getMetrics () { return {} }
+      }
+    }
 
     const Event = module.exports.Event
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,18 +24,22 @@
         "zig-build": "^0.1.1"
       },
       "optionalDependencies": {
-        "solarwinds-apm-bindings-arm64-linux-gnu-14": "14.1.0",
-        "solarwinds-apm-bindings-arm64-linux-gnu-16": "14.1.0",
-        "solarwinds-apm-bindings-arm64-linux-gnu-18": "14.1.0",
-        "solarwinds-apm-bindings-arm64-linux-musl-14": "14.1.0",
-        "solarwinds-apm-bindings-arm64-linux-musl-16": "14.1.0",
-        "solarwinds-apm-bindings-arm64-linux-musl-18": "14.1.0",
-        "solarwinds-apm-bindings-x64-linux-gnu-14": "14.1.0",
-        "solarwinds-apm-bindings-x64-linux-gnu-16": "14.1.0",
-        "solarwinds-apm-bindings-x64-linux-gnu-18": "14.1.0",
-        "solarwinds-apm-bindings-x64-linux-musl-14": "14.1.0",
-        "solarwinds-apm-bindings-x64-linux-musl-16": "14.1.0",
-        "solarwinds-apm-bindings-x64-linux-musl-18": "14.1.0"
+        "solarwinds-apm-bindings-arm64-linux-gnu-14": "15.0.2",
+        "solarwinds-apm-bindings-arm64-linux-gnu-16": "15.0.2",
+        "solarwinds-apm-bindings-arm64-linux-gnu-18": "15.0.2",
+        "solarwinds-apm-bindings-arm64-linux-gnu-20": "15.0.2",
+        "solarwinds-apm-bindings-arm64-linux-musl-14": "15.0.2",
+        "solarwinds-apm-bindings-arm64-linux-musl-16": "15.0.2",
+        "solarwinds-apm-bindings-arm64-linux-musl-18": "15.0.2",
+        "solarwinds-apm-bindings-arm64-linux-musl-20": "15.0.2",
+        "solarwinds-apm-bindings-x64-linux-gnu-14": "15.0.2",
+        "solarwinds-apm-bindings-x64-linux-gnu-16": "15.0.2",
+        "solarwinds-apm-bindings-x64-linux-gnu-18": "15.0.2",
+        "solarwinds-apm-bindings-x64-linux-gnu-20": "15.0.2",
+        "solarwinds-apm-bindings-x64-linux-musl-14": "15.0.2",
+        "solarwinds-apm-bindings-x64-linux-musl-16": "15.0.2",
+        "solarwinds-apm-bindings-x64-linux-musl-18": "15.0.2",
+        "solarwinds-apm-bindings-x64-linux-musl-20": "15.0.2"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -2980,6 +2984,186 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/solarwinds-apm-bindings-arm64-linux-gnu-14": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-arm64-linux-gnu-14/-/solarwinds-apm-bindings-arm64-linux-gnu-14-15.0.2.tgz",
+      "integrity": "sha512-owyGZW0187x1kF1PVIJJ6EtWdsUB+29o3Af/WeFn2nY2IB57F/4lUBat9uhsyl/g5KQMDPtdgHfAdE/lV3LfuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14 <15"
+      }
+    },
+    "node_modules/solarwinds-apm-bindings-arm64-linux-gnu-16": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-arm64-linux-gnu-16/-/solarwinds-apm-bindings-arm64-linux-gnu-16-15.0.2.tgz",
+      "integrity": "sha512-DljFY+Dq0hl/o1DjhsFCHazJifDdLXj/SPUaFXxQoFZXX6TuvAZZennP7rmO0TSENGygNQihl27/uOfsySDMig==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16 <17"
+      }
+    },
+    "node_modules/solarwinds-apm-bindings-arm64-linux-gnu-18": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-arm64-linux-gnu-18/-/solarwinds-apm-bindings-arm64-linux-gnu-18-15.0.2.tgz",
+      "integrity": "sha512-aKJ0NJ7aXhUG35z0w920grMm4Tly3mBnX/34kpoWmZ6yp3GrTT1So3Y1ReoL1AjwEkZFrT0gYbP5PpAwZVoQYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18 <19"
+      }
+    },
+    "node_modules/solarwinds-apm-bindings-arm64-linux-musl-14": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-arm64-linux-musl-14/-/solarwinds-apm-bindings-arm64-linux-musl-14-15.0.2.tgz",
+      "integrity": "sha512-G7UIyWC8pmLLN7BFd2MZ5mTErQSfJuDjDsijQBNdneZIyqeZ/ozP6Rx3F2qt8OrS2sjPMU2gK1sqHua7+dYy0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14 <15"
+      }
+    },
+    "node_modules/solarwinds-apm-bindings-arm64-linux-musl-16": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-arm64-linux-musl-16/-/solarwinds-apm-bindings-arm64-linux-musl-16-15.0.2.tgz",
+      "integrity": "sha512-qCLy7thpQqbz3REKOcA5mS5rkVoMYlsa1Cndjt7zqjMJgy7g851099VN2nsQR1F0JJbDLb9DxcK6DXa/pSZi6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16 <17"
+      }
+    },
+    "node_modules/solarwinds-apm-bindings-arm64-linux-musl-18": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-arm64-linux-musl-18/-/solarwinds-apm-bindings-arm64-linux-musl-18-15.0.2.tgz",
+      "integrity": "sha512-na1H9hgi7ZKNI8K08Xt1fuE/1tk9Ii6O/nyt4/3VieOTTZ40pMeHXxMqfip3JqcteMeWp6qiPuNT+pHFWUn4Ew==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18 <19"
+      }
+    },
+    "node_modules/solarwinds-apm-bindings-x64-linux-gnu-14": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-x64-linux-gnu-14/-/solarwinds-apm-bindings-x64-linux-gnu-14-15.0.2.tgz",
+      "integrity": "sha512-Hab6vm8ku6Zjz71YSP/hoK+oqRIpy26rZ648YEbaDBv+gJxDRroIietjzJMNz1UfghR2USI1tWR2ezFUEFy2Pw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14 <15"
+      }
+    },
+    "node_modules/solarwinds-apm-bindings-x64-linux-gnu-16": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-x64-linux-gnu-16/-/solarwinds-apm-bindings-x64-linux-gnu-16-15.0.2.tgz",
+      "integrity": "sha512-AbmeVjxMtAlKuZR/Yl927DmDCPcLxqgf1drCVid3l7Ng7D/RUPC2vfrPpitIDE8A2nLk73qgAvLM5ElxbuGwoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16 <17"
+      }
+    },
+    "node_modules/solarwinds-apm-bindings-x64-linux-gnu-18": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-x64-linux-gnu-18/-/solarwinds-apm-bindings-x64-linux-gnu-18-15.0.2.tgz",
+      "integrity": "sha512-R0pt59rKGkSAZHfsz6yiKDnZvRBhZCFR0u0h90mgZSb9CyG/aPDBYjh0gJCwSpy2jSVQg6z04oMMh68hZx86mA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18 <19"
+      }
+    },
+    "node_modules/solarwinds-apm-bindings-x64-linux-musl-14": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-x64-linux-musl-14/-/solarwinds-apm-bindings-x64-linux-musl-14-15.0.2.tgz",
+      "integrity": "sha512-yl3PbM9cBPtqgwuhaiXsR4E0XuMKEo2KO8hJCcB9PfcvOxTMDYUJVojYm2jb2lCWksq6XuEznDet5GHFoXJ3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14 <15"
+      }
+    },
+    "node_modules/solarwinds-apm-bindings-x64-linux-musl-16": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-x64-linux-musl-16/-/solarwinds-apm-bindings-x64-linux-musl-16-15.0.2.tgz",
+      "integrity": "sha512-Z6uMNRMBqTNs4bhDE99vHW3j+NXa8T8ygtljXIz4f9Z5H+zcdgUvA93cuCszCwdAkDNLNXmC45CiCEHIKNRqZw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16 <17"
+      }
+    },
+    "node_modules/solarwinds-apm-bindings-x64-linux-musl-18": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-x64-linux-musl-18/-/solarwinds-apm-bindings-x64-linux-musl-18-15.0.2.tgz",
+      "integrity": "sha512-F6Gx/rxS3xzC+KJMDG/w5aOlkuO7fFHOuwu57sC8dZXjbu9x6YFSEPrla0G6d0cnET3ywMP5JZj2VqR0QYnXqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18 <19"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -5586,6 +5770,78 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "solarwinds-apm-bindings-arm64-linux-gnu-14": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-arm64-linux-gnu-14/-/solarwinds-apm-bindings-arm64-linux-gnu-14-15.0.2.tgz",
+      "integrity": "sha512-owyGZW0187x1kF1PVIJJ6EtWdsUB+29o3Af/WeFn2nY2IB57F/4lUBat9uhsyl/g5KQMDPtdgHfAdE/lV3LfuA==",
+      "optional": true
+    },
+    "solarwinds-apm-bindings-arm64-linux-gnu-16": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-arm64-linux-gnu-16/-/solarwinds-apm-bindings-arm64-linux-gnu-16-15.0.2.tgz",
+      "integrity": "sha512-DljFY+Dq0hl/o1DjhsFCHazJifDdLXj/SPUaFXxQoFZXX6TuvAZZennP7rmO0TSENGygNQihl27/uOfsySDMig==",
+      "optional": true
+    },
+    "solarwinds-apm-bindings-arm64-linux-gnu-18": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-arm64-linux-gnu-18/-/solarwinds-apm-bindings-arm64-linux-gnu-18-15.0.2.tgz",
+      "integrity": "sha512-aKJ0NJ7aXhUG35z0w920grMm4Tly3mBnX/34kpoWmZ6yp3GrTT1So3Y1ReoL1AjwEkZFrT0gYbP5PpAwZVoQYw==",
+      "optional": true
+    },
+    "solarwinds-apm-bindings-arm64-linux-musl-14": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-arm64-linux-musl-14/-/solarwinds-apm-bindings-arm64-linux-musl-14-15.0.2.tgz",
+      "integrity": "sha512-G7UIyWC8pmLLN7BFd2MZ5mTErQSfJuDjDsijQBNdneZIyqeZ/ozP6Rx3F2qt8OrS2sjPMU2gK1sqHua7+dYy0g==",
+      "optional": true
+    },
+    "solarwinds-apm-bindings-arm64-linux-musl-16": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-arm64-linux-musl-16/-/solarwinds-apm-bindings-arm64-linux-musl-16-15.0.2.tgz",
+      "integrity": "sha512-qCLy7thpQqbz3REKOcA5mS5rkVoMYlsa1Cndjt7zqjMJgy7g851099VN2nsQR1F0JJbDLb9DxcK6DXa/pSZi6Q==",
+      "optional": true
+    },
+    "solarwinds-apm-bindings-arm64-linux-musl-18": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-arm64-linux-musl-18/-/solarwinds-apm-bindings-arm64-linux-musl-18-15.0.2.tgz",
+      "integrity": "sha512-na1H9hgi7ZKNI8K08Xt1fuE/1tk9Ii6O/nyt4/3VieOTTZ40pMeHXxMqfip3JqcteMeWp6qiPuNT+pHFWUn4Ew==",
+      "optional": true
+    },
+    "solarwinds-apm-bindings-x64-linux-gnu-14": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-x64-linux-gnu-14/-/solarwinds-apm-bindings-x64-linux-gnu-14-15.0.2.tgz",
+      "integrity": "sha512-Hab6vm8ku6Zjz71YSP/hoK+oqRIpy26rZ648YEbaDBv+gJxDRroIietjzJMNz1UfghR2USI1tWR2ezFUEFy2Pw==",
+      "optional": true
+    },
+    "solarwinds-apm-bindings-x64-linux-gnu-16": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-x64-linux-gnu-16/-/solarwinds-apm-bindings-x64-linux-gnu-16-15.0.2.tgz",
+      "integrity": "sha512-AbmeVjxMtAlKuZR/Yl927DmDCPcLxqgf1drCVid3l7Ng7D/RUPC2vfrPpitIDE8A2nLk73qgAvLM5ElxbuGwoA==",
+      "optional": true
+    },
+    "solarwinds-apm-bindings-x64-linux-gnu-18": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-x64-linux-gnu-18/-/solarwinds-apm-bindings-x64-linux-gnu-18-15.0.2.tgz",
+      "integrity": "sha512-R0pt59rKGkSAZHfsz6yiKDnZvRBhZCFR0u0h90mgZSb9CyG/aPDBYjh0gJCwSpy2jSVQg6z04oMMh68hZx86mA==",
+      "optional": true
+    },
+    "solarwinds-apm-bindings-x64-linux-musl-14": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-x64-linux-musl-14/-/solarwinds-apm-bindings-x64-linux-musl-14-15.0.2.tgz",
+      "integrity": "sha512-yl3PbM9cBPtqgwuhaiXsR4E0XuMKEo2KO8hJCcB9PfcvOxTMDYUJVojYm2jb2lCWksq6XuEznDet5GHFoXJ3Vg==",
+      "optional": true
+    },
+    "solarwinds-apm-bindings-x64-linux-musl-16": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-x64-linux-musl-16/-/solarwinds-apm-bindings-x64-linux-musl-16-15.0.2.tgz",
+      "integrity": "sha512-Z6uMNRMBqTNs4bhDE99vHW3j+NXa8T8ygtljXIz4f9Z5H+zcdgUvA93cuCszCwdAkDNLNXmC45CiCEHIKNRqZw==",
+      "optional": true
+    },
+    "solarwinds-apm-bindings-x64-linux-musl-18": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings-x64-linux-musl-18/-/solarwinds-apm-bindings-x64-linux-musl-18-15.0.2.tgz",
+      "integrity": "sha512-F6Gx/rxS3xzC+KJMDG/w5aOlkuO7fFHOuwu57sC8dZXjbu9x6YFSEPrla0G6d0cnET3ywMP5JZj2VqR0QYnXqQ==",
+      "optional": true
     },
     "string_decoder": {
       "version": "0.10.31",

--- a/package.json
+++ b/package.json
@@ -52,14 +52,18 @@
     "solarwinds-apm-bindings-arm64-linux-gnu-14": "15.0.2",
     "solarwinds-apm-bindings-arm64-linux-gnu-16": "15.0.2",
     "solarwinds-apm-bindings-arm64-linux-gnu-18": "15.0.2",
+    "solarwinds-apm-bindings-arm64-linux-gnu-20": "15.0.2",
     "solarwinds-apm-bindings-arm64-linux-musl-14": "15.0.2",
     "solarwinds-apm-bindings-arm64-linux-musl-16": "15.0.2",
     "solarwinds-apm-bindings-arm64-linux-musl-18": "15.0.2",
+    "solarwinds-apm-bindings-arm64-linux-musl-20": "15.0.2",
     "solarwinds-apm-bindings-x64-linux-gnu-14": "15.0.2",
     "solarwinds-apm-bindings-x64-linux-gnu-16": "15.0.2",
     "solarwinds-apm-bindings-x64-linux-gnu-18": "15.0.2",
+    "solarwinds-apm-bindings-x64-linux-gnu-20": "15.0.2",
     "solarwinds-apm-bindings-x64-linux-musl-14": "15.0.2",
     "solarwinds-apm-bindings-x64-linux-musl-16": "15.0.2",
-    "solarwinds-apm-bindings-x64-linux-musl-18": "15.0.2"
+    "solarwinds-apm-bindings-x64-linux-musl-18": "15.0.2",
+    "solarwinds-apm-bindings-x64-linux-musl-20": "15.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "node build.js",
-    "build:all": "docker compose -f dev/docker-compose.build.yml up node-14 && docker compose -f dev/docker-compose.build.yml up node-16 && docker compose -f dev/docker-compose.build.yml up node-18 ; docker compose -f dev/docker-compose.build.yml down",
+    "build:all": "docker compose -f dev/docker-compose.build.yml up node-14 && docker compose -f dev/docker-compose.build.yml up node-16 && docker compose -f dev/docker-compose.build.yml up node-18 && docker compose -f dev/docker-compose.build.yml up node-20 ; docker compose -f dev/docker-compose.build.yml down",
     "test": "./test.sh",
     "lint": "eslint . --ext .json,.js,.yml --fix",
     "dev": "dev/start.sh",

--- a/src/metrics/eventloop.cc
+++ b/src/metrics/eventloop.cc
@@ -1,11 +1,10 @@
-#include <nan.h>
+#include <uv.h>
 #include <map>
 
 #include "hdr_histogram.h"
 #include "eventloop.h"
 
 namespace ao { namespace metrics { namespace eventloop {
-using namespace v8;
 
 // state = 0 not initialized
 // state = 1 initialized
@@ -94,7 +93,7 @@ bool stop() {
   return true;
 }
 
-bool getInterval(const v8::Local<v8::Object> obj) {
+bool getInterval(Napi::Object& obj) {
   if (!enabled) {
     return false;
   }
@@ -102,7 +101,7 @@ bool getInterval(const v8::Local<v8::Object> obj) {
   std::map<std::string, double>::iterator it;
   for (it = PERCENTILES.begin(); it != PERCENTILES.end(); it++) {
     const int64_t p = hdr_value_at_percentile(hist, it->second);
-    Nan::Set(obj, Nan::New(it->first).ToLocalChecked(), Nan::New<Number>(p));
+    obj.Set(it->first, Napi::Number::New(obj.Env(), p));
   }
 
   // the next two values are NaN if no eventloops executed so default them to 0.
@@ -123,10 +122,10 @@ bool getInterval(const v8::Local<v8::Object> obj) {
     hdr_reset(hist);
   }
 
-  Nan::Set(obj, Nan::New("min").ToLocalChecked(), Nan::New<Number>(min));
-  Nan::Set(obj, Nan::New("max").ToLocalChecked(), Nan::New<Number>(max));
-  Nan::Set(obj, Nan::New("mean").ToLocalChecked(), Nan::New<Number>(mean));
-  Nan::Set(obj, Nan::New("stddev").ToLocalChecked(), Nan::New<Number>(stddev));
+  obj.Set("min", Napi::Number::New(obj.Env(), min));
+  obj.Set("max", Napi::Number::New(obj.Env(), max));
+  obj.Set("mean", Napi::Number::New(obj.Env(), mean));
+  obj.Set("stddev", Napi::Number::New(obj.Env(), stddev));
 
   return true;
 }

--- a/src/metrics/eventloop.h
+++ b/src/metrics/eventloop.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <nan.h>
+#include <napi.h>
 
 namespace ao { namespace metrics { namespace eventloop {
   bool start();
   bool stop();
-  bool getInterval(const v8::Local<v8::Object>);
+  bool getInterval(Napi::Object&);
 }}}

--- a/src/metrics/gc.cc
+++ b/src/metrics/gc.cc
@@ -28,7 +28,7 @@
 namespace ao { namespace metrics { namespace gc {
 using namespace v8;
 
-void set_histogram_values(hdr_histogram*, Local<Object>);
+void set_histogram_values(hdr_histogram*, Napi::Object&);
 
 typedef struct GCData {
 	uint64_t gcTime;
@@ -136,32 +136,32 @@ bool stop () {
   return status;
 }
 
-bool getInterval(const v8::Local<v8::Object> obj) {
+bool getInterval(Napi::Object& obj) {
 
   if (!enabled) {
     return false;
   }
 
   uint64_t count = raw.gcCount - interval_base.gcCount;
-  Nan::Set(obj, Nan::New("gcCount").ToLocalChecked(), Nan::New<Number>(count));
+  obj.Set("gcCout", Napi::Number::New(obj.Env(), count));
 
   uint64_t time = raw.gcTime - interval_base.gcTime;
-  Nan::Set(obj, Nan::New("gcTime").ToLocalChecked(), Nan::New<Number>(time));
+  obj.Set("gcTime", Napi::Number::New(obj.Env(), time));
 
   uint64_t majorCount = raw.majorCount - interval_base.majorCount;
   uint64_t minorCount = raw.minorCount - interval_base.minorCount;
 
-  Local<Object> major = Nan::New<Object>();
-  Local<Object> minor = Nan::New<Object>();
+  auto major = Napi::Object::New(obj.Env());
+  auto minor = Napi::Object::New(obj.Env());
 
   set_histogram_values(h_major, major);
   set_histogram_values(h_minor, minor);
 
-  Nan::Set(obj, Nan::New("major").ToLocalChecked(), major);
-  Nan::Set(obj, Nan::New("minor").ToLocalChecked(), minor);
+  obj.Set("major", major);
+  obj.Set("minor", minor);
 
-  Nan::Set(major, Nan::New("count").ToLocalChecked(), Nan::New<Number>(majorCount));
-  Nan::Set(minor, Nan::New("count").ToLocalChecked(), Nan::New<Number>(minorCount));
+  major.Set("count", Napi::Number::New(major.Env(), majorCount));
+  minor.Set("count", Napi::Number::New(minor.Env(), minorCount));
 
   // reset the interval base values
   interval_base.gcCount = raw.gcCount;
@@ -176,11 +176,11 @@ bool getInterval(const v8::Local<v8::Object> obj) {
   return true;
 }
 
-void set_histogram_values(hdr_histogram* h, Local<Object> obj) {
+void set_histogram_values(hdr_histogram* h, Napi::Object& obj) {
   std::map<std::string, double>::iterator it;
   for (it = PERCENTILES.begin(); it != PERCENTILES.end(); it++) {
     const int64_t p = hdr_value_at_percentile(h, it->second);
-    Nan::Set(obj, Nan::New(it->first).ToLocalChecked(), Nan::New<Number>(p));
+    obj.Set(it->first, Napi::Number::New(obj.Env(), p));
   }
 
   // the next two values are NaN if no GCs executed so default them to 0.
@@ -201,10 +201,10 @@ void set_histogram_values(hdr_histogram* h, Local<Object> obj) {
     hdr_reset(h);
   }
 
-  Nan::Set(obj, Nan::New("min").ToLocalChecked(), Nan::New<Number>(min));
-  Nan::Set(obj, Nan::New("max").ToLocalChecked(), Nan::New<Number>(max));
-  Nan::Set(obj, Nan::New("mean").ToLocalChecked(), Nan::New<Number>(mean));
-  Nan::Set(obj, Nan::New("stddev").ToLocalChecked(), Nan::New<Number>(stddev));
+  obj.Set("min", Napi::Number::New(obj.Env(), min));
+  obj.Set("max", Napi::Number::New(obj.Env(), max));
+  obj.Set("mean", Napi::Number::New(obj.Env(), mean));
+  obj.Set("stddev", Napi::Number::New(obj.Env(), stddev));
 }
 
 }}} // namespace ao::metrics::gc

--- a/src/metrics/gc.h
+++ b/src/metrics/gc.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <nan.h>
+#include <napi.h>
 
 namespace ao { namespace metrics { namespace gc {
   bool start();
   bool stop();
-  bool getInterval(const v8::Local<v8::Object>);
+  bool getInterval(Napi::Object&);
 }}}

--- a/src/metrics/metrics.cc
+++ b/src/metrics/metrics.cc
@@ -1,60 +1,56 @@
-#include <nan.h>
+#include <napi.h>
 #include "gc.h"
 #include "eventloop.h"
 #include "process.h"
 
 namespace ao { namespace metrics {
-  using namespace v8;
 
-  NAN_METHOD(start) {
+  Napi::Value start(const Napi::CallbackInfo& info) {
     int status = 0;
     if (!gc::start()) status |= 0x1;
     if (!eventloop::start()) status |= 0x2;
     if (!process::start()) status |= 0x4;
 
-    info.GetReturnValue().Set(status);
+    return Napi::Number::New(info.Env(), status);
   }
 
-  NAN_METHOD(stop) {
+  Napi::Value stop(const Napi::CallbackInfo& info) {
     int status = 0;
     if (!gc::stop()) status |= 0x1;
     if (!eventloop::stop()) status |= 0x2;
     if (!process::stop()) status |= 0x4;
 
-    info.GetReturnValue().Set(status);
+    return Napi::Number::New(info.Env(), status);
   }
 
-  NAN_METHOD(getMetrics) {
-    Local<Object> metrics = Nan::New<Object>();
+  Napi::Value getMetrics(const Napi::CallbackInfo& info) {
+    auto metrics = Napi::Object::New(info.Env());
 
-    Local<Object> obj = Nan::New<Object>();
+    auto obj = Napi::Object::New(info.Env());
     if (gc::getInterval(obj)) {
-      Nan::Set(metrics, Nan::New("gc").ToLocalChecked(), obj);
+      metrics.Set("gc", obj);
     }
 
-    obj = Nan::New<Object>();
+    obj = Napi::Object::New(info.Env());
     if (eventloop::getInterval(obj)) {
-      Nan::Set(metrics, Nan::New("eventloop").ToLocalChecked(), obj);
+      metrics.Set("eventloop", obj);
     }
 
-    obj = Nan::New<Object>();
+    obj = Napi::Object::New(info.Env());
     if (process::getInterval(obj)) {
-      Nan::Set(metrics, Nan::New("process").ToLocalChecked(), obj);
+      metrics.Set("process", obj);
     }
 
-    info.GetReturnValue().Set(metrics);
+    return metrics;
   }
 
-  NAN_MODULE_INIT(init) {
-    Nan::HandleScope scope;
+  Napi::Object init(Napi::Env env, Napi::Object exports) {
+    exports.Set("start", Napi::Function::New(env, start));
+    exports.Set("stop", Napi::Function::New(env, stop));
+    exports.Set("getMetrics", Napi::Function::New(env, getMetrics));
 
-    Nan::Set(target, Nan::New("start").ToLocalChecked(),
-        Nan::GetFunction(Nan::New<FunctionTemplate>(start)).ToLocalChecked());
-    Nan::Set(target, Nan::New("stop").ToLocalChecked(),
-        Nan::GetFunction(Nan::New<FunctionTemplate>(stop)).ToLocalChecked());
-    Nan::Set(target, Nan::New("getMetrics").ToLocalChecked(),
-        Nan::GetFunction(Nan::New<FunctionTemplate>(getMetrics)).ToLocalChecked());
+    return exports;
   }
 
-  NODE_MODULE(metrics, init)
+  NODE_API_MODULE(metrics, init)
 }} // namespace ao::metrics

--- a/src/metrics/process.cc
+++ b/src/metrics/process.cc
@@ -1,11 +1,10 @@
-#include <nan.h>
+#include <uv.h>
 #include <map>
 
 #include "hdr_histogram.h"
 #include "process.h"
 
 namespace ao { namespace metrics { namespace process {
-using namespace v8;
 
 bool enabled = true;
 uv_rusage_t prev_rusage;
@@ -28,7 +27,7 @@ int64_t usec_time (uv_timeval_t t) {
 //
 // get interval data
 //
-bool getInterval(const v8::Local<v8::Object> obj) {
+bool getInterval(Napi::Object& obj) {
   if (!enabled) {
     return false;
   }
@@ -39,8 +38,8 @@ bool getInterval(const v8::Local<v8::Object> obj) {
   const uint64_t user_time = usec_time(rusage.ru_utime) - usec_time(prev_rusage.ru_utime);
   const uint64_t sys_time = usec_time(rusage.ru_stime) - usec_time(prev_rusage.ru_stime);
 
-  Nan::Set(obj, Nan::New("user").ToLocalChecked(), Nan::New<Number>(user_time));
-  Nan::Set(obj, Nan::New("system").ToLocalChecked(), Nan::New<Number>(sys_time));
+  obj.Set("user", Napi::Number::New(obj.Env(), user_time));
+  obj.Set("system", Napi::Number::New(obj.Env(), sys_time));
 
   prev_rusage = rusage;
 

--- a/src/metrics/process.h
+++ b/src/metrics/process.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <nan.h>
+#include <napi.h>
 
 namespace ao { namespace metrics { namespace process {
   bool start();
   bool stop();
-  bool getInterval(const v8::Local<v8::Object>);
+  bool getInterval(Napi::Object&);
 }}}


### PR DESCRIPTION
Adds build support for Node 20 and adds it to CI. This required to migrate the metrics addon from `nan` to Node-API except where `nan` is strictly required and use C++17 to support the new V8 headers.
Also makes it possible to load the main addon only if the metrics fail to load and replace them with noops.